### PR TITLE
feat: add assistant privacy controls for dashboard vs widget

### DIFF
--- a/src/app/api/assistants/route.ts
+++ b/src/app/api/assistants/route.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from 'next/server';
-import { getAssistants } from '@/lib/actions/assistants';
+import { getAssistants, getPublicAssistants } from '@/lib/actions/assistants';
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const assistants = await getAssistants();
+    const { searchParams } = new URL(request.url);
+    const isWidget = searchParams.get('widget') === 'true';
+
+    // If this is a widget request, only return public assistants
+    const assistants = isWidget ? await getPublicAssistants() : await getAssistants();
+
     return NextResponse.json({ assistants });
   } catch (error) {
     console.error('Assistants API Error:', error);

--- a/src/components/AssistantsManager.tsx
+++ b/src/components/AssistantsManager.tsx
@@ -25,7 +25,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
-import { createAssistant, updateAssistant, deleteAssistant } from '@/lib/actions/assistants';
+import { createAssistant, updateAssistant, deleteAssistant, toggleAssistantPublic } from '@/lib/actions/assistants';
 import { showSuccess, showError } from '@/lib/toast';
 import { type Assistant } from '@/types';
 
@@ -77,7 +77,7 @@ export default function AssistantsManager({ assistants }: AssistantsManagerProps
   const handleUpdateAssistant = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!editingAssistant) return;
-    
+
     setIsSubmitting(true);
     try {
       const formData = new FormData(e.currentTarget);
@@ -90,6 +90,19 @@ export default function AssistantsManager({ assistants }: AssistantsManagerProps
       showError('Failed to update assistant', 'Please try again.');
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const handleTogglePublic = async (assistantId: string, isPublic: boolean) => {
+    try {
+      await toggleAssistantPublic(assistantId, !isPublic);
+      showSuccess(
+        !isPublic ? 'Assistant made public!' : 'Assistant made private!',
+        !isPublic ? 'It will now appear in the widget.' : 'It will no longer appear in the widget.'
+      );
+    } catch (error) {
+      console.error('Error toggling assistant public status:', error);
+      showError('Failed to update assistant', 'Please try again.');
     }
   };
 
@@ -109,7 +122,16 @@ export default function AssistantsManager({ assistants }: AssistantsManagerProps
               className="flex items-center justify-between p-4 border border-gray-200 rounded-lg"
             >
               <div>
-                <h3 className="font-semibold text-gray-900">{assistant.name}</h3>
+                <div className="flex items-center gap-2 mb-1">
+                  <h3 className="font-semibold text-gray-900">{assistant.name}</h3>
+                  <span className={`inline-block px-2 py-1 text-xs rounded-full ${
+                    assistant.is_public
+                      ? 'bg-green-100 text-green-800'
+                      : 'bg-gray-100 text-gray-800'
+                  }`}>
+                    {assistant.is_public ? 'Public' : 'Private'}
+                  </span>
+                </div>
                 <p className="text-gray-600 text-sm">{assistant.description}</p>
                 {assistant.category && (
                   <span className="inline-block px-2 py-1 text-xs bg-blue-100 text-blue-800 rounded-full mt-1">
@@ -121,9 +143,21 @@ export default function AssistantsManager({ assistants }: AssistantsManagerProps
                 </p>
               </div>
               <div className="flex gap-2">
-                <Button 
-                  variant="outline" 
-                  size="sm" 
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className={`cursor-pointer ${
+                    assistant.is_public
+                      ? 'text-orange-600 border-orange-200 hover:bg-orange-50'
+                      : 'text-green-600 border-green-200 hover:bg-green-50'
+                  }`}
+                  onClick={() => handleTogglePublic(assistant.id, assistant.is_public || false)}
+                >
+                  {assistant.is_public ? 'Make Private' : 'Make Public'}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
                   className="cursor-pointer"
                   onClick={() => handleEditAssistant(assistant)}
                 >
@@ -131,9 +165,9 @@ export default function AssistantsManager({ assistants }: AssistantsManagerProps
                 </Button>
                 <AlertDialog>
                   <AlertDialogTrigger asChild>
-                    <Button 
-                      variant="outline" 
-                      size="sm" 
+                    <Button
+                      variant="outline"
+                      size="sm"
                       className="text-red-600 border-red-200 cursor-pointer"
                     >
                       Delete

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -197,7 +197,9 @@ export default function ChatWidget({ className = '', modelSettings, isEmbed = fa
 
   const loadAssistants = async () => {
     try {
-      const response = await fetch('/api/assistants');
+      // For widget (embed) mode, only load public assistants
+      const url = isEmbed ? '/api/assistants?widget=true' : '/api/assistants';
+      const response = await fetch(url);
       const data = await response.json();
       if (data.assistants) {
         setAssistants(data.assistants);

--- a/src/lib/actions/assistants.ts
+++ b/src/lib/actions/assistants.ts
@@ -6,7 +6,7 @@ import { type InsertAssistant, type UpdateAssistant } from '@/lib/supabase/types
 
 export async function getAssistants() {
   const supabase = await createClient()
-  
+
   const { data: assistants, error } = await supabase
     .from('assistants')
     .select('*')
@@ -15,6 +15,23 @@ export async function getAssistants() {
   if (error) {
     console.error('Error fetching assistants:', error)
     throw new Error('Failed to fetch assistants')
+  }
+
+  return assistants || []
+}
+
+export async function getPublicAssistants() {
+  const supabase = await createClient()
+
+  const { data: assistants, error } = await supabase
+    .from('assistants')
+    .select('*')
+    .eq('is_public', true)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('Error fetching public assistants:', error)
+    throw new Error('Failed to fetch public assistants')
   }
 
   return assistants || []
@@ -79,6 +96,25 @@ export async function updateAssistant(id: string, formData: FormData) {
   if (error) {
     console.error('Error updating assistant:', error)
     throw new Error('Failed to update assistant')
+  }
+
+  revalidatePath('/dashboard/assistants')
+}
+
+export async function toggleAssistantPublic(id: string, isPublic: boolean) {
+  const supabase = await createClient()
+
+  const { error } = await supabase
+    .from('assistants')
+    .update({
+      is_public: isPublic,
+      updated_at: new Date().toISOString()
+    })
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error toggling assistant public status:', error)
+    throw new Error('Failed to update assistant public status')
   }
 
   revalidatePath('/dashboard/assistants')

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -18,6 +18,7 @@ export interface Database {
           description: string
           system_prompt: string
           category: string | null
+          is_public: boolean | null
           created_at: string
           updated_at: string | null
         }
@@ -27,6 +28,7 @@ export interface Database {
           description: string
           system_prompt: string
           category?: string | null
+          is_public?: boolean | null
           created_at?: string
           updated_at?: string | null
         }
@@ -36,6 +38,7 @@ export interface Database {
           description?: string
           system_prompt?: string
           category?: string | null
+          is_public?: boolean | null
           created_at?: string
           updated_at?: string | null
         }

--- a/supabase-migrations/add-assistant-privacy.sql
+++ b/supabase-migrations/add-assistant-privacy.sql
@@ -1,0 +1,13 @@
+-- Add is_public field to assistants table
+-- New assistants will be private by default
+ALTER TABLE public.assistants
+ADD COLUMN IF NOT EXISTS is_public BOOLEAN DEFAULT FALSE;
+
+-- Create index for better performance when filtering public assistants
+CREATE INDEX IF NOT EXISTS assistants_is_public_idx ON public.assistants(is_public);
+
+-- Make existing assistants public to maintain current behavior
+UPDATE public.assistants SET is_public = TRUE WHERE is_public IS NULL;
+
+-- Add comment for documentation
+COMMENT ON COLUMN public.assistants.is_public IS 'Whether this assistant is publicly available in the widget (default: false)';


### PR DESCRIPTION
- Add is_public boolean field to assistants table (default false)
- Create getPublicAssistants function to filter only public assistants
- Update API route to return public assistants only for widget requests
- Add toggle button in dashboard to make assistants public/private
- Include SQL migration for database schema update

This allows testing new assistants privately in dashboard before making them public for Squarespace widget.